### PR TITLE
Add e2e coverage for nx deploy and fix executor names

### DIFF
--- a/e2e/aws-cdk-v2-e2e/tests/aws-cdk.spec.ts
+++ b/e2e/aws-cdk-v2-e2e/tests/aws-cdk.spec.ts
@@ -52,7 +52,7 @@ describe('aws-cdk-v2 e2e', () => {
     writeFileSync(
       stubPath,
       `#!/usr/bin/env bash\n` +
-        `echo \"$@\" > \"${logFile}\"\n` +
+        `echo "$@" > "${logFile}"\n` +
         'exit 0\n'
     );
     chmodSync(stubPath, 0o755);

--- a/packages/aws-cdk-v2/src/generators/application/application.spec.ts
+++ b/packages/aws-cdk-v2/src/generators/application/application.spec.ts
@@ -18,6 +18,15 @@ describe('aws-cdk generator', () => {
     expect(config).toBeDefined();
   });
 
+  it('should register executors on generated project', async () => {
+    await generator(appTree, options);
+    const config = readProjectConfiguration(appTree, 'test');
+
+    expect(config.targets?.deploy?.executor).toBe('@wolsok/nx-aws-cdk-v2:deploy');
+    expect(config.targets?.destroy?.executor).toBe('@wolsok/nx-aws-cdk-v2:destroy');
+    expect(config.targets?.bootstrap?.executor).toBe('@wolsok/nx-aws-cdk-v2:bootstrap');
+  });
+
   it('directory option', async () => {
     const directory = 'sub';
     const directoryOptions = Object.assign({}, options);

--- a/packages/aws-cdk-v2/src/generators/application/application.ts
+++ b/packages/aws-cdk-v2/src/generators/application/application.ts
@@ -80,15 +80,15 @@ export async function applicationGenerator(host: Tree, options: ApplicationSchem
     sourceRoot: `${normalizedOptions.projectRoot}/src`,
     targets: {
       deploy: {
-        executor: '@ago-dev/nx-aws-cdk-v2:deploy',
+        executor: '@wolsok/nx-aws-cdk-v2:deploy',
         options: {},
       },
       destroy: {
-        executor: '@ago-dev/nx-aws-cdk-v2:destroy',
+        executor: '@wolsok/nx-aws-cdk-v2:destroy',
         options: {},
       },
       bootstrap: {
-        executor: '@ago-dev/nx-aws-cdk-v2:bootstrap',
+        executor: '@wolsok/nx-aws-cdk-v2:bootstrap',
         options: {},
       },
     },


### PR DESCRIPTION
## Summary
- ensure generated projects reference the `@wolsok/nx-aws-cdk-v2` executors
- add unit coverage confirming the generator registers the correct targets
- add an e2e test that stubs `npx` to verify running `nx <project>:deploy` invokes the CDK CLI

## Testing
- CI=1 npm run e2e:aws-cdk

------
https://chatgpt.com/codex/tasks/task_e_68ef7a0c4178832cb95fff91b317b55f