### PR TITLE
Improve e2e checks for module workspaces, deploy stubs, and synth target

### DIFF
--- a/e2e/aws-cdk-v2-e2e/tests/aws-cdk.spec.ts
+++ b/e2e/aws-cdk-v2-e2e/tests/aws-cdk.spec.ts
@@ -1,5 +1,13 @@
-import { checkFilesExist, ensureNxProject, readJson, runNxCommandAsync, uniq } from '@nx/plugin/testing';
-import { logger } from '@nx/devkit';
+import {
+  checkFilesExist,
+  ensureNxProject,
+  readJson,
+  runNxCommandAsync,
+  uniq,
+  updateFile,
+} from '@nx/plugin/testing';
+import { ProjectConfiguration, logger } from '@nx/devkit';
+import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 
 describe('aws-cdk-v2 e2e', () => {
@@ -7,10 +15,132 @@ describe('aws-cdk-v2 e2e', () => {
     ensureNxProject('@wolsok/nx-aws-cdk-v2', path.join('dist/packages/aws-cdk-v2'));
   }, 120000);
 
+  async function readProjectConfigurationFromNx(projectName: string): Promise<ProjectConfiguration> {
+    const result = await runNxCommandAsync(`show project ${projectName} --json`);
+    return JSON.parse(result.stdout) as ProjectConfiguration;
+  }
+
   it('should create aws-cdk', async () => {
     const plugin = uniq('aws-cdk-v2');
 
     await runNxCommandAsync(`generate @wolsok/nx-aws-cdk-v2:application ${plugin}`);
+  }, 120000);
+
+  it('should generate when package.json uses type module', async () => {
+    const plugin = uniq('aws-cdk-v2');
+    const originalPackageType = readJson('package.json').type;
+
+    updateFile('package.json', (content) => {
+      const packageJson = JSON.parse(content);
+      packageJson.type = 'module';
+      return `${JSON.stringify(packageJson, null, 2)}\n`;
+    });
+
+    try {
+      await runNxCommandAsync(`generate @wolsok/nx-aws-cdk-v2:application ${plugin}`);
+
+      const project = await readProjectConfigurationFromNx(plugin);
+      const sourceRoot = project.sourceRoot ?? `${project.root}/src`;
+
+      expect(() => checkFilesExist(`${sourceRoot}/main.ts`)).not.toThrow();
+    } finally {
+      updateFile('package.json', (content) => {
+        const packageJson = JSON.parse(content);
+
+        if (originalPackageType) {
+          packageJson.type = originalPackageType;
+        } else {
+          delete packageJson.type;
+        }
+
+        return `${JSON.stringify(packageJson, null, 2)}\n`;
+      });
+    }
+  }, 120000);
+
+  it('should run deploy target via nx using the cdk cli', async () => {
+    const plugin = uniq('aws-cdk-v2');
+
+    await runNxCommandAsync(`generate @wolsok/nx-aws-cdk-v2:application ${plugin}`);
+    const project = await readProjectConfigurationFromNx(plugin);
+    expect(project.root).toBeDefined();
+
+    const workspaceRoot = process.env.NX_WORKSPACE_ROOT ?? process.cwd();
+    const logDir = path.join(workspaceRoot, 'tmp', `cdk-stub-${plugin}`);
+    const logFile = path.join(logDir, 'invocation.log');
+    mkdirSync(logDir, { recursive: true });
+    const isWindows = process.platform === 'win32';
+    const posixStub = path.join(logDir, 'cdk');
+    const cmdStub = path.join(logDir, 'cdk.cmd');
+
+    writeFileSync(
+      posixStub,
+      `#!/usr/bin/env bash\n` +
+        `printf 'cdk' >> "${logFile}"\n` +
+        'for arg in "$@"; do\n' +
+        `  printf ' %s' "$arg" >> "${logFile}"\n` +
+        'done\n' +
+        `printf '\n' >> "${logFile}"\n` +
+        'exit 0\n'
+    );
+    chmodSync(posixStub, 0o755);
+
+    if (isWindows) {
+      writeFileSync(
+        cmdStub,
+        ['@echo off', 'setlocal enabledelayedexpansion', `>>"${logFile}" echo cdk %*`, 'exit /b 0'].join('\r\n'),
+        'utf-8'
+      );
+    }
+
+    const env = {
+      ...process.env,
+      PATH: `${logDir}${path.delimiter}${process.env.PATH ?? ''}`,
+    };
+
+    try {
+      await runNxCommandAsync(`run ${plugin}:deploy`, { env });
+
+      const invocations = readFileSync(logFile, 'utf-8')
+        .split(/\r?\n/)
+        .filter((line) => line.length > 0);
+      const cdkInvocation = invocations.find((line) => /\bcdk\b/.test(line));
+
+      expect(cdkInvocation).toBeDefined();
+      expect(cdkInvocation).toContain('deploy');
+      expect(cdkInvocation).toContain(`${project.root}/src/main.ts`);
+    } finally {
+      rmSync(logDir, { recursive: true, force: true });
+    }
+  }, 120000);
+
+  it('should synthesize the stack via nx using the cdk cli', async () => {
+    const plugin = uniq('aws-cdk-v2');
+
+    await runNxCommandAsync(`generate @wolsok/nx-aws-cdk-v2:application ${plugin}`);
+    const project = await readProjectConfigurationFromNx(plugin);
+
+    const outDir = path.join(process.cwd(), 'cdk.out');
+
+    try {
+      const synthResult = await runNxCommandAsync(`run ${plugin}:synth`);
+
+      expect(synthResult.stdout).toContain(plugin);
+      expect(() => checkFilesExist(`cdk.out/${plugin}.template.json`)).not.toThrow();
+      expect(() => checkFilesExist(`cdk.out/manifest.json`)).not.toThrow();
+
+      const manifest = JSON.parse(readFileSync(path.join(outDir, 'manifest.json'), 'utf-8'));
+      const artifact = manifest?.artifacts?.[plugin];
+
+      expect(artifact?.type).toBe('aws:cloudformation:stack');
+      expect(artifact?.properties?.templateFile).toBe(`${plugin}.template.json`);
+      expect(artifact?.environment).toBeDefined();
+      expect(artifact?.environment).toContain('aws://');
+
+      expect(() => checkFilesExist(`${project.root}/cdk.out/${plugin}.template.json`)).toThrow();
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
   }, 120000);
 
   describe('--directory', () => {

--- a/packages/aws-cdk-v2/README.md
+++ b/packages/aws-cdk-v2/README.md
@@ -62,9 +62,10 @@ Options:
 
 ### Targets
 
-Generated applications expose several functions to the CLI that allow users to deploy, destroy and bootstrap.
+Generated applications expose several functions to the CLI that allow users to synthesize, deploy, destroy and bootstrap.
 
 ```shell
+nx synth myApp
 nx deploy myApp
 nx destroy myApp
 nx bootstrap myApp --profile=profile

--- a/packages/aws-cdk-v2/executors.json
+++ b/packages/aws-cdk-v2/executors.json
@@ -11,6 +11,11 @@
       "schema": "./src/executors/destroy/schema.json",
       "description": "destroy executor"
     },
+    "synth": {
+      "implementation": "./src/executors/synth/synth",
+      "schema": "./src/executors/synth/schema.json",
+      "description": "synth executor"
+    },
     "bootstrap": {
       "implementation": "./src/executors/bootstrap/bootstrap",
       "schema": "./src/executors/bootstrap/schema.json",

--- a/packages/aws-cdk-v2/src/executors/synth/schema.d.ts
+++ b/packages/aws-cdk-v2/src/executors/synth/schema.d.ts
@@ -1,0 +1,3 @@
+export interface SynthExecutorSchema {
+  stacks?: string;
+}

--- a/packages/aws-cdk-v2/src/executors/synth/schema.json
+++ b/packages/aws-cdk-v2/src/executors/synth/schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "title": "synth executor",
+  "description": "",
+  "type": "object",
+  "properties": {
+    "stacks": {
+      "type": "string",
+      "description": "use synth named STACKS"
+    }
+  },
+  "required": []
+}

--- a/packages/aws-cdk-v2/src/executors/synth/synth.spec.ts
+++ b/packages/aws-cdk-v2/src/executors/synth/synth.spec.ts
@@ -1,0 +1,151 @@
+import { EventEmitter } from 'events';
+import * as childProcess from 'child_process';
+import { logger } from '@nx/devkit';
+
+import executor from './synth';
+import { SynthExecutorSchema } from './schema';
+import { generateCommandString, LARGE_BUFFER } from '../../utils/executor.util';
+import { mockExecutorContext } from '../../utils/testing';
+
+class MockChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+}
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  exec: jest.fn(() => new MockChildProcess()),
+}));
+
+const options: SynthExecutorSchema = {};
+
+const nodeCommandWithRelativePath = generateCommandString('synth', 'apps/proj');
+
+describe('aws-cdk-v2 synth Executor', () => {
+  const context = mockExecutorContext('synth');
+
+  beforeEach(async () => {
+    jest.spyOn(logger, 'debug');
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('run cdk synth command', async () => {
+    const execMock = (childProcess.exec as unknown) as jest.Mock;
+    let mockProcess;
+    execMock.mockImplementation(() => {
+      mockProcess = new MockChildProcess();
+      return mockProcess;
+    });
+    const promise = executor(options, context);
+    mockProcess.emit('close', 0);
+    await promise;
+    expect(childProcess.exec).toHaveBeenCalledWith(
+      nodeCommandWithRelativePath,
+      expect.objectContaining({
+        cwd: context.root,
+        env: process.env,
+        maxBuffer: LARGE_BUFFER,
+      })
+    );
+    expect(logger.debug).toHaveBeenLastCalledWith(`Executing command: ${nodeCommandWithRelativePath}`);
+  });
+
+  it('run cdk synth command stack', async () => {
+    const execMock = (childProcess.exec as unknown) as jest.Mock;
+    let mockProcess;
+    execMock.mockImplementation(() => {
+      mockProcess = new MockChildProcess();
+      return mockProcess;
+    });
+    const option: SynthExecutorSchema = Object.assign({}, options);
+    const stackName = 'test';
+    option['stacks'] = stackName;
+    const promise = executor(option, context);
+    mockProcess.emit('close', 0);
+    await promise;
+    expect(childProcess.exec).toHaveBeenCalledWith(
+      `${nodeCommandWithRelativePath} ${stackName}`,
+      expect.objectContaining({
+        env: process.env,
+        maxBuffer: LARGE_BUFFER,
+      })
+    );
+
+    expect(logger.debug).toHaveBeenLastCalledWith(`Executing command: ${nodeCommandWithRelativePath} ${stackName}`);
+  });
+
+  it('run cdk synth command context options', async () => {
+    const execMock = (childProcess.exec as unknown) as jest.Mock;
+    let mockProcess;
+    execMock.mockImplementation(() => {
+      mockProcess = new MockChildProcess();
+      return mockProcess;
+    });
+    const option: SynthExecutorSchema = Object.assign({}, options);
+    const contextOptionString = 'key=value';
+    option['context'] = contextOptionString;
+    const promise = executor(option, context);
+    mockProcess.emit('close', 0);
+    await promise;
+    expect(childProcess.exec).toHaveBeenCalledWith(
+      `${nodeCommandWithRelativePath} --context ${contextOptionString}`,
+      expect.objectContaining({
+        env: process.env,
+        maxBuffer: LARGE_BUFFER,
+      })
+    );
+
+    expect(logger.debug).toHaveBeenLastCalledWith(
+      `Executing command: ${nodeCommandWithRelativePath} --context ${contextOptionString}`
+    );
+  });
+
+  it('run cdk synth command with multiple context options', async () => {
+    const execMock = (childProcess.exec as unknown) as jest.Mock;
+    let mockProcess;
+    execMock.mockImplementation(() => {
+      mockProcess = new MockChildProcess();
+      return mockProcess;
+    });
+    const option: SynthExecutorSchema = Object.assign({}, options);
+    const contextOptions = ['firstKey=firstValue', 'secondKey=secondValue'];
+    option['context'] = contextOptions;
+    const promise = executor(option, context);
+    mockProcess.emit('close', 0);
+    await promise;
+    const contextCmd = contextOptions.map((option) => `--context ${option}`).join(' ');
+    expect(childProcess.exec).toHaveBeenCalledWith(
+      `${nodeCommandWithRelativePath} ${contextCmd}`,
+      expect.objectContaining({
+        env: process.env,
+        maxBuffer: LARGE_BUFFER,
+      })
+    );
+
+    expect(logger.debug).toHaveBeenLastCalledWith(`Executing command: ${nodeCommandWithRelativePath} ${contextCmd}`);
+  });
+
+  it('run cdk synth command with boolean context option', async () => {
+    const execMock = (childProcess.exec as unknown) as jest.Mock;
+    let mockProcess;
+    execMock.mockImplementation(() => {
+      mockProcess = new MockChildProcess();
+      return mockProcess;
+    });
+    const option: SynthExecutorSchema = Object.assign({}, options);
+    option['exclusively'] = true;
+    const promise = executor(option, context);
+    mockProcess.emit('close', 0);
+    await promise;
+    expect(childProcess.exec).toHaveBeenCalledWith(
+      `${nodeCommandWithRelativePath} --exclusively true`,
+      expect.objectContaining({
+        env: process.env,
+        maxBuffer: LARGE_BUFFER,
+      })
+    );
+
+    expect(logger.debug).toHaveBeenLastCalledWith(`Executing command: ${nodeCommandWithRelativePath} --exclusively true`);
+  });
+});

--- a/packages/aws-cdk-v2/src/executors/synth/synth.ts
+++ b/packages/aws-cdk-v2/src/executors/synth/synth.ts
@@ -1,0 +1,44 @@
+import { ExecutorContext } from '@nx/devkit';
+
+import { ParsedExecutorInterface } from '../../interfaces/parsed-executor.interface';
+import { createCommand, parseArgs, runCommandProcess } from '../../utils/executor.util';
+import { SynthExecutorSchema } from './schema';
+
+export interface ParsedSynthExecutorOption extends ParsedExecutorInterface {
+  stacks?: string[];
+  sourceRoot: string;
+  root: string;
+}
+
+export default async function runExecutor(options: SynthExecutorSchema, context: ExecutorContext) {
+  const normalizedOptions = normalizeOptions(options, context);
+  const result = await runSynth(normalizedOptions, context);
+
+  return {
+    success: result,
+  };
+}
+
+function runSynth(options: ParsedSynthExecutorOption, context: ExecutorContext) {
+  const command = createCommand('synth', options);
+  return runCommandProcess(command, context.root);
+}
+
+function normalizeOptions(options: SynthExecutorSchema, context: ExecutorContext): ParsedSynthExecutorOption {
+  const parsedArgs = parseArgs(options);
+  let stacks;
+
+  if (Object.prototype.hasOwnProperty.call(options, 'stacks')) {
+    stacks = options.stacks;
+  }
+
+  const { sourceRoot, root } = context?.projectsConfigurations?.projects[context.projectName] ?? {};
+
+  return {
+    ...options,
+    parseArgs: parsedArgs,
+    stacks,
+    sourceRoot,
+    root,
+  };
+}

--- a/packages/aws-cdk-v2/src/generators/application/application.spec.ts
+++ b/packages/aws-cdk-v2/src/generators/application/application.spec.ts
@@ -18,6 +18,16 @@ describe('aws-cdk generator', () => {
     expect(config).toBeDefined();
   });
 
+  it('should register executors on generated project', async () => {
+    await generator(appTree, options);
+    const config = readProjectConfiguration(appTree, 'test');
+
+    expect(config.targets?.deploy?.executor).toBe('@wolsok/nx-aws-cdk-v2:deploy');
+    expect(config.targets?.synth?.executor).toBe('@wolsok/nx-aws-cdk-v2:synth');
+    expect(config.targets?.destroy?.executor).toBe('@wolsok/nx-aws-cdk-v2:destroy');
+    expect(config.targets?.bootstrap?.executor).toBe('@wolsok/nx-aws-cdk-v2:bootstrap');
+  });
+
   it('directory option', async () => {
     const directory = 'sub';
     const directoryOptions = Object.assign({}, options);

--- a/packages/aws-cdk-v2/src/generators/application/application.ts
+++ b/packages/aws-cdk-v2/src/generators/application/application.ts
@@ -80,15 +80,19 @@ export async function applicationGenerator(host: Tree, options: ApplicationSchem
     sourceRoot: `${normalizedOptions.projectRoot}/src`,
     targets: {
       deploy: {
-        executor: '@ago-dev/nx-aws-cdk-v2:deploy',
+        executor: '@wolsok/nx-aws-cdk-v2:deploy',
+        options: {},
+      },
+      synth: {
+        executor: '@wolsok/nx-aws-cdk-v2:synth',
         options: {},
       },
       destroy: {
-        executor: '@ago-dev/nx-aws-cdk-v2:destroy',
+        executor: '@wolsok/nx-aws-cdk-v2:destroy',
         options: {},
       },
       bootstrap: {
-        executor: '@ago-dev/nx-aws-cdk-v2:bootstrap',
+        executor: '@wolsok/nx-aws-cdk-v2:bootstrap',
         options: {},
       },
     },

--- a/packages/aws-cdk-v2/src/utils/executor.util.ts
+++ b/packages/aws-cdk-v2/src/utils/executor.util.ts
@@ -4,6 +4,7 @@ import { DeployExecutorSchema } from '../executors/deploy/schema';
 import { ParsedExecutorInterface } from '../interfaces/parsed-executor.interface';
 import { logger, detectPackageManager } from '@nx/devkit';
 import { BootstrapExecutorSchema } from '../executors/bootstrap/schema';
+import { SynthExecutorSchema } from '../executors/synth/schema';
 import { getPackageJson } from '@nx/eslint-plugin/src/utils/package-json-utils';
 import * as path from 'node:path';
 
@@ -28,7 +29,9 @@ export function generateCommandString(command: string, appPath: string) {
   return `${packageManagerExecutor} cdk -a "${generatePath}" ${command}`;
 }
 
-export function parseArgs(options: DeployExecutorSchema | BootstrapExecutorSchema): Record<string, string | string[]> {
+export function parseArgs(
+  options: DeployExecutorSchema | BootstrapExecutorSchema | SynthExecutorSchema
+): Record<string, string | string[]> {
   const keys = Object.keys(options);
   return keys
     .filter((prop) => executorPropKeys.indexOf(prop) < 0)


### PR DESCRIPTION
## Summary
- capture the generated project metadata with `nx show project` so the e2e test can verify the main entrypoint even when the workspace layout changes under `type: module`
- stub the CDK CLI through a PATH-first shim so the deploy e2e test records the exact command on every platform while still preventing a real AWS call
- add a `synth` executor/target, document it, extend the tests to cover both the executor logic and an e2e run that executes `cdk synth`, and ensure the test removes any generated `cdk.out` artifacts afterward

## Testing
- CI=1 npm run e2e:aws-cdk -- --runInBand --skip-nx-cache
- CI=1 npx nx test aws-cdk-v2 --skip-nx-cache

------
https://chatgpt.com/codex/tasks/task_e_68ef7a0c4178832cb95fff91b317b55f