### PR TITLE
fix: remove registry-url from release workflows to unbreak npm OIDC publishing

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -17,11 +17,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No registry-url here: actions/setup-node writes an _authToken line to
+      # .npmrc referencing NODE_AUTH_TOKEN whenever registry-url is set, even
+      # though it's unused now. That placeholder makes npm think token auth is
+      # already configured, so it skips the OIDC trusted-publishing handshake
+      # (see actions/setup-node#1551). npm publishes to the default registry
+      # (registry.npmjs.org) without it.
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          registry-url: 'https://registry.npmjs.org'
           cache: npm
 
       - name: Install dependencies
@@ -30,9 +35,10 @@ jobs:
         env:
           CI: true
 
-      # npm >=11.5.1 is required for OIDC trusted publishing.
+      # OIDC trusted publishing requires npm >=11.5.1; pin to a known-good
+      # major so a future npm release can't silently change publish behavior.
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g "npm@>=11.5.1 <12"
 
       - name: Set Version
         run: npm --prefix ./packages/aws-cdk-v2 version ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No registry-url here: actions/setup-node writes an _authToken line to
+      # .npmrc referencing NODE_AUTH_TOKEN whenever registry-url is set, even
+      # though it's unused now. That placeholder makes npm think token auth is
+      # already configured, so it skips the OIDC trusted-publishing handshake
+      # (see actions/setup-node#1551). npm publishes to the default registry
+      # (registry.npmjs.org) without it.
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          registry-url: 'https://registry.npmjs.org'
           cache: npm
 
       - name: Install dependencies
@@ -30,9 +35,10 @@ jobs:
         env:
           CI: true
 
-      # npm >=11.5.1 is required for OIDC trusted publishing.
+      # OIDC trusted publishing requires npm >=11.5.1; pin to a known-good
+      # major so a future npm release can't silently change publish behavior.
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g "npm@>=11.5.1 <12"
 
       - name: Set Version
         run: npm --prefix ./packages/aws-cdk-v2 version ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Follow-up to #475's OIDC trusted-publishing switch, found by a post-merge code review.
- `actions/setup-node`'s `registry-url` input still writes an `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` line to `.npmrc` even though `NODE_AUTH_TOKEN` is no longer set. npm then sees an auth token "configured" and skips the OIDC handshake entirely instead of falling back to it ([actions/setup-node#1551](https://github.com/actions/setup-node/issues/1551)), so `npm publish` would fail rather than use trusted publishing.
- Remove `registry-url` from both `release.yml` and `pre_release.yml` — npm defaults to `registry.npmjs.org` without it.
- Pin the npm self-update step to `>=11.5.1 <12` instead of unconditionally tracking `latest`, so a future npm major can't silently change publish/OIDC behavior on a release run.

## Test plan
- YAML syntax validated for both workflow files.
- Can't fully exercise the publish step outside of an actual GitHub release event; verified the fix matches the documented `actions/setup-node` interaction and npm's own OIDC trusted-publishing guidance (no `registry-url` needed).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UR4UfSYBLn8MHcdVtS2nCA)_