### PR TITLE
chore(release): prepare 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A comprehensive Nx plugin for developing, deploying, and managing AWS CDK v2 app
 
 - **AWS CDK v2 Integration**: Full support for AWS CDK v2 within Nx workspaces
 - **Application Generator**: Quickly scaffold new AWS CDK applications with proper structure
-- **Multiple Executors**: Deploy, destroy, and bootstrap AWS CDK applications with ease
+- **Multiple Executors**: Deploy, synthesize, destroy, and bootstrap AWS CDK applications with ease
 - **Nx Workspace Benefits**: Leverage Nx's caching, dependency graph, and affected commands
 - **TypeScript Support**: Fully typed interfaces for better developer experience
 
@@ -78,22 +78,32 @@ Options:
 The plugin provides several executors to manage your AWS CDK applications:
 
 - **deploy**: Deploy your CDK application to AWS
+- **synth**: Synthesize your CDK application into a CloudFormation template
 - **destroy**: Remove your CDK application from AWS
 - **bootstrap**: Bootstrap AWS environments for CDK deployment
 
 ### Examples
 
 **Deploy an application:**
+
 ```bash
 nx deploy myApp
 ```
 
+**Synthesize an application:**
+
+```bash
+nx synth myApp
+```
+
 **Destroy an application:**
+
 ```bash
 nx destroy myApp
 ```
 
 **Bootstrap an AWS environment:**
+
 ```bash
 # Using a profile
 nx bootstrap myApp --profile=myProfile

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -6,6 +6,7 @@ This document provides detailed API documentation for all executors and generato
 
 - [Executors](#executors)
   - [Deploy Executor](#deploy-executor)
+  - [Synth Executor](#synth-executor)
   - [Destroy Executor](#destroy-executor)
   - [Bootstrap Executor](#bootstrap-executor)
 - [Generators](#generators)
@@ -43,6 +44,34 @@ nx deploy my-cdk-app --stacks="MyStack1,MyStack2"
 **Implementation Details:**
 
 The Deploy executor creates a CDK deploy command with the specified options and runs it in the project's directory. It normalizes the options, creates the command, and executes it using the AWS CDK CLI.
+
+### Synth Executor
+
+The Synth executor is used to synthesize AWS CDK applications into CloudFormation templates without deploying them.
+
+**Usage:**
+```bash
+nx synth <project-name> [options]
+```
+
+**Options:**
+
+| Option | Type | Description |
+| ------ | ---- | ----------- |
+| `stacks` | string | Specifies which stacks to synthesize. If not provided, all stacks in the application will be synthesized. |
+
+**Example:**
+```bash
+# Synthesize all stacks in the application
+nx synth my-cdk-app
+
+# Synthesize specific stacks
+nx synth my-cdk-app --stacks="MyStack1,MyStack2"
+```
+
+**Implementation Details:**
+
+The Synth executor creates a CDK synth command with the specified options and runs it in the project's directory. It normalizes the options, creates the command, and executes it using the AWS CDK CLI. The emitted templates are written to the application's `cdk.out` directory.
 
 ### Destroy Executor
 
@@ -144,7 +173,7 @@ nx generate @wolsok/nx-aws-cdk-v2:application my-cdk-app --unitTestRunner=none
 The Application generator creates a new AWS CDK application with the specified options. It:
 1. Normalizes the options
 2. Runs the Init generator to set up the necessary dependencies
-3. Creates the project configuration with deploy, destroy, and bootstrap targets
+3. Creates the project configuration with deploy, synth, destroy, and bootstrap targets
 4. Adds the application files from templates
 5. Optionally sets up Jest for testing
 6. Formats the files (unless skipFormat is true)

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -40,7 +40,7 @@ This document contains a detailed list of actionable improvement tasks for the n
 [ ] Add support for CDK watch mode in executors
 [ ] Implement a new generator for creating CDK constructs
 [ ] Add support for CDK diff command as a new executor
-[ ] Implement CDK synth command as a new executor
+[x] Implement CDK synth command as a new executor
 [ ] Add support for CDK context management
 [ ] Implement integration with AWS SSO for authentication
 [ ] Add support for CDK hot swapping for faster development

--- a/packages/aws-cdk-v2/package.json
+++ b/packages/aws-cdk-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolsok/nx-aws-cdk-v2",
-  "version": "2.3.0",
+  "version": "2.6.0",
   "main": "src/index.js",
   "generators": "./generators.json",
   "executors": "./executors.json",


### PR DESCRIPTION
Release preparation for **2.6.0**. Merging this does not publish anything — publishing is triggered by creating the GitHub Release for tag `2.6.0` (see below).

## Why 2.6.0

Last release was [2.5.0](https://github.com/WolfSoko/nx-aws-cdk-v2/releases/tag/2.5.0) (npm `latest` is also `2.5.0`). Since then `main` picked up a new feature (`feat: add synth executor and coverage`) plus fixes and dependency updates, and nothing breaking — so a minor bump.

## Changes

- Bump `packages/aws-cdk-v2/package.json` from `2.3.0` to `2.6.0`. The checked-in version had drifted, since the release workflow overwrites it from the tag name at publish time; this brings the repo back in sync with what actually ships.
- Document the **synth** executor. It is registered in `executors.json` and the `application` generator already wires a `synth` target into generated projects, but it was absent from the README and `docs/api-documentation.md`, so the headline feature of this release was undiscoverable.
  - `README.md`: added to the features line, the executor list, and the examples section.
  - `docs/api-documentation.md`: new "Synth Executor" section (usage, `stacks` option, examples, implementation notes) plus a table-of-contents entry; corrected the application generator's description to mention the `synth` target.
- `docs/tasks.md`: ticked off "Implement CDK synth command as a new executor".

No source or behavior changes — the plugin code is untouched.

## Release notes draft for tag `2.6.0`

**Features**
- New `synth` executor — run `nx synth my-cdk-app` to synthesize a CDK app into CloudFormation templates without deploying. Supports a `stacks` option to narrow which stacks are synthesized. Generated applications get a `synth` target automatically.

**Fixes**
- Removed `registry-url` from the release workflows so npm's OIDC trusted publishing handshake is no longer skipped.
- Stabilized the `aws-cdk-v2` e2e tests.

**Maintenance**
- Nx workspace migrated from v21 to v23.1.1.
- Broad dependency refresh, including `aws-cdk` 2.1137.0, `aws-cdk-lib` 2.265.0, Angular CLI v22, Jest 30, TypeScript 6, ESLint 10.
- Added `CLAUDE.md` with build/test commands and an architecture overview.

## Verification

Ran locally against the branch with the cloud runner disabled:

- `nx lint aws-cdk-v2` — 0 errors (3 pre-existing "file ignored" warnings)
- `nx test aws-cdk-v2` — 6 suites, 18 tests passed
- `nx build aws-cdk-v2` — succeeds; `dist/packages/aws-cdk-v2/package.json` reports `2.6.0`

CI on this PR is green across all five checks (`main`, `test`, CodeQL `Analyze (actions)`, CodeQL `Analyze (javascript-typescript)`, and the CodeQL summary check), including e2e.

## Note on a pre-existing issue (not fixed here)

`packages/aws-cdk-v2/package.json` declares `ng-update.migrations: "./migrations.json"`, but no `migrations.json` exists in the package or in the build output. Every published version to date carries this dangling reference, so `nx migrate @wolsok/nx-aws-cdk-v2` cannot resolve it. It is out of scope for a release-prep change, but worth a follow-up.

## Publishing

After merge, create a GitHub Release with tag `2.6.0` targeting `main` and publish it as a full release (not a pre-release). That fires `.github/workflows/release.yml`, which sets the version from the tag, builds, and publishes to npm under `latest`. This will be the first release to exercise the OIDC trusted-publishing fix from `1a355c9`, so the publish step is worth watching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dokumentation**
  - Der neue Synth-Executor ist in der Feature-Liste und API-Dokumentation beschrieben.
  - Nutzung, Optionen und Beispiele für `nx synth myApp` wurden ergänzt.
  - Die Dokumentation erklärt die Erstellung von CloudFormation-Templates im Ausgabeordner.
  - Der Status der Implementierungsaufgabe wurde aktualisiert.

- **Verbesserungen**
  - Die Paketversion wurde auf Version 2.6.0 aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->