### PR TITLE
fix(ci): make release Set Version step tolerate an already-correct version

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -40,8 +40,13 @@ jobs:
       - name: Update npm
         run: npm install -g "npm@>=11.5.1 <12"
 
+      # --allow-same-version: `npm version X` exits 1 with "Version not changed"
+      # when package.json already declares X. The checked-in version is kept in
+      # sync with the released tag, so that is the normal case, not an error.
+      # --no-git-tag-version: this is a detached checkout of the tag that gets
+      # thrown away, so there is no point committing and tagging in it.
       - name: Set Version
-        run: npm --prefix ./packages/aws-cdk-v2 version ${{ github.ref_name }}
+        run: npm --prefix ./packages/aws-cdk-v2 version ${{ github.ref_name }} --allow-same-version --no-git-tag-version
 
       - name: build
         run: npm run build:aws-cdk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,13 @@ jobs:
       - name: Update npm
         run: npm install -g "npm@>=11.5.1 <12"
 
+      # --allow-same-version: `npm version X` exits 1 with "Version not changed"
+      # when package.json already declares X. The checked-in version is kept in
+      # sync with the released tag, so that is the normal case, not an error.
+      # --no-git-tag-version: this is a detached checkout of the tag that gets
+      # thrown away, so there is no point committing and tagging in it.
       - name: Set Version
-        run: npm --prefix ./packages/aws-cdk-v2 version ${{ github.ref_name }}
+        run: npm --prefix ./packages/aws-cdk-v2 version ${{ github.ref_name }} --allow-same-version --no-git-tag-version
 
       - name: build
         run: npm run build:aws-cdk


### PR DESCRIPTION
Fixes the `Release` run for 2.6.0, which [failed](https://github.com/WolfSoko/nx-aws-cdk-v2/actions/runs/32178577693) at the `Set Version` step:

```
Run npm --prefix ./packages/aws-cdk-v2 version 2.6.0
npm error Version not changed
Process completed with exit code 1
```

## Cause

`npm version X` exits 1 with `Version not changed` when `package.json` already declares `X`.

That step only ever succeeded because the checked-in version was stale — it sat at `2.3.0` while releases went out as 2.4.0 and 2.5.0, so `npm version <tag>` always had something to change. #478 synced `packages/aws-cdk-v2/package.json` to `2.6.0`, which turned the step into a no-op and failed the run before it reached `build` or `deploy`.

So the latent bug is that the release pipeline only worked while the repo's declared version was wrong. Reverting the sync would paper over it and leave the same trap for the next person who tidies the version.

## Fix

```diff
-        run: npm --prefix ./packages/aws-cdk-v2 version ${{ github.ref_name }}
+        run: npm --prefix ./packages/aws-cdk-v2 version ${{ github.ref_name }} --allow-same-version --no-git-tag-version
```

- `--allow-same-version` — the step is now correct whether or not the checked-in version already matches the tag.
- `--no-git-tag-version` — npm otherwise creates a commit and tag inside a detached checkout of the tag that is discarded at the end of the job. It served no purpose and is a second latent failure source (it would collide with a pre-existing `v<tag>`).

Applied to both `release.yml` and `pre_release.yml`; `pre_release.yml` carried the identical step and the identical bug.

## Verification

Reproduced the failure and confirmed the fix against a scratch package, since this step cannot be exercised by the normal CI run:

| Case | Command | Result |
| ---- | ------- | ------ |
| package.json already `2.6.0`, old command | `npm version 2.6.0` | ❌ exit 1, `Version not changed` — reproduces the failure |
| package.json already `2.6.0`, new command | `npm version 2.6.0 --allow-same-version --no-git-tag-version` | ✅ exit 0, version stays `2.6.0` |
| package.json `2.6.0` → different tag | `npm version 2.7.1 --allow-same-version --no-git-tag-version` | ✅ exit 0, version written as `2.7.1` |

Both workflow files were also checked to still parse as YAML with the `Set Version` step intact.

## Release status

Nothing was published — the run died before the `deploy` step. npm `latest` is still `2.5.0` and `@wolsok/nx-aws-cdk-v2@2.6.0` returns 404, so the version number is still free.

Because a `release` event runs the workflow file as it exists at the tagged commit, re-running the failed run would replay the old, broken workflow. After this merges, the `2.6.0` tag and its GitHub Release need to be deleted and re-created against the new `main` so the fixed workflow is the one that runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_019SpLpxtpPEuHwNiAPCDVvE)_