### PR TITLE
fix(release): push the release commit with a PAT, past main's ruleset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,15 @@ name: Release
 # GitHub release that a second workflow reacts to) is deliberate: GitHub does
 # not start other workflow runs from events created by the default
 # GITHUB_TOKEN, so a split flow would need a personal access token just to
-# bridge the two workflows. Keeping it to one job needs only the default
-# token.
+# bridge the two workflows.
+#
+# A personal access token is needed here regardless, for a different reason:
+# main has a ruleset requiring the CI status check, which a direct push -
+# including this job's release commit - can never itself satisfy. The
+# RELEASE_GH_TOKEN secret authenticates the push as the repo owner's account
+# instead of the default GITHUB_TOKEN's GitHub Actions identity, so it can be
+# added to the ruleset's bypass list (Settings -> Rules -> Rulesets) without
+# granting a blanket bypass to the GitHub Actions app.
 on:
   workflow_run:
     workflows: [CI]
@@ -65,11 +72,14 @@ jobs:
     steps:
       # Pinned to the exact commit CI validated (not just "main"), so a
       # commit that landed after this CI run finished - and hasn't been
-      # tested - never gets released.
+      # tested - never gets released. The token makes the later git push
+      # authenticate as the repo owner's account (see the top-of-file
+      # comment) rather than the default GITHUB_TOKEN.
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_GH_TOKEN }}
 
       - uses: actions/setup-node@v7
         with:
@@ -91,7 +101,7 @@ jobs:
       - name: Version, build, changelog & publish
         run: node tools/release.js
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
 
       # Self-Healing CI: apply Nx Cloud's suggested fixes for failing tasks.
       # Learn more at https://nx.dev/ci/features/self-healing-ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,10 +137,14 @@ stays hand-maintained.
 `tools/release.js` runs `nx release`'s version, changelog and publish steps as separate calls (with a
 build in between, so the published package picks up the bumped version) instead of the single
 composite `nx release` command, and does the version-bump git commit/tag/push itself — see the
-comments in that file for why. This also means the whole flow needs only the default `GITHUB_TOKEN`
-(`contents: write` to push the release commit/tag, `id-token: write` for npm OIDC): unlike a design
-where a created GitHub release triggers a _second_ workflow to publish, there's no second workflow
-here for GitHub to refuse to start from a `GITHUB_TOKEN`-authored event, so no personal access token
-is needed.
+comments in that file for why.
+
+Pushing that release commit needs a personal access token stored as the `RELEASE_GH_TOKEN` repository
+secret. `main` has a ruleset requiring the CI status check on every push, which a direct push —
+including this job's own release commit — can never itself satisfy, so it has to authenticate as an
+account on the ruleset's bypass list (Settings → Rules → Rulesets) rather than as the default
+`GITHUB_TOKEN`'s GitHub Actions identity, which isn't on that list. `RELEASE_GH_TOKEN` is a personal
+access token for the repo owner's account, added individually to the bypass list — not a blanket
+bypass for GitHub Actions.
 
 There is no beta/pre-release channel — this plugin doesn't publish prereleases.


### PR DESCRIPTION
## What does this PR do?

Fixes the first live failure of #490's release workflow: pushing the release commit to `main` was rejected —

```
remote: - Required status check "Lint, test, build & e2e" is expected.
remote: - Code scanning is waiting for results from CodeQL for the commit 0c4a094.
! [remote rejected] HEAD -> main (push declined due to repository rule violations)
```

`main` has a ruleset requiring those checks on every push, and a direct push — including this job's own release commit — can never itself satisfy that (there's no time for a CI run to complete against a commit that doesn't exist yet until the push lands).

We discussed three ways around this (tag-only with no commit to `main`, a version-bump PR + auto-merge, or a bypass); a blanket bypass for the GitHub Actions app wasn't acceptable, so this uses a **personal access token scoped to the repo owner's account** instead — `checkout` and the release step now authenticate with `RELEASE_GH_TOKEN` rather than the default `GITHUB_TOKEN`, so the push is attributable to (and can be individually allow-listed for) that account rather than granting a blanket bypass to GitHub Actions.

### Required setup

1. Create a personal access token (classic or fine-grained, `contents: write` on this repo) for your account.
2. Add it as the **`RELEASE_GH_TOKEN`** repository secret.
3. Add your account to the `main` ruleset's bypass list: **Settings → Rules → Rulesets** → the ruleset targeting `main` → Bypass list → add yourself, "Always allow" (not just "for pull requests").

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation only
- [x] Build / CI / chore

## Checklist

- [x] The commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (enforced by commitlint)
- [x] `npm run check` passes (lint, unit tests and build)
- [ ] `npm run e2e:aws-cdk` passes, or the change cannot affect the e2e suite — not applicable, this only touches the release workflow, not plugin code or its tests
- [ ] Tests were added or updated for the change — not applicable, this is CI/release tooling with no testable plugin behaviour
- [x] User facing changes are reflected in the README and in `docs/` — `CONTRIBUTING.md` updated

## Related issues

Follow-up to #490

---
_Generated by [Claude Code](https://claude.ai/code/session_0117rnJjhvcayCCdUJGsJkjg)_